### PR TITLE
Add input flag aliases and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lq - low overhead yq/tq/... implementation
+# lq - low overhead yq/tq/jq cli
 [![CI](https://github.com/clux/lq/actions/workflows/release.yml/badge.svg)](https://github.com/clux/lq/actions/workflows/release.yml)
 [![Crates.io](https://img.shields.io/crates/v/lq.svg)](https://crates.io/crates/lq)
 [![dependency status](https://deps.rs/repo/github/clux/lq/status.svg)](https://deps.rs/repo/github/clux/lq)
@@ -159,7 +159,8 @@ Split a bundle of yaml files into a yaml file per Kubernetes `.metadata.name` ke
 
 ```sh
 mkdir -p crds
-curl -sSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.82.1/stripped-down-crds.yaml | lq . -y --split '"crds/" + (.metadata.name) + ".yaml"'
+curl -sSL https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.82.1/stripped-down-crds.yaml \
+  | lq . -y --split '"crds/" + (.metadata.name) + ".yaml"'
 ```
 
 #### In Place Edits

--- a/README.md
+++ b/README.md
@@ -67,11 +67,6 @@ labels:
   app: controller
 name: controller
 namespace: default
-
-$ lq '.spec.template.spec.containers[].image' -r < test/grafana.yaml
-quay.io/kiwigrid/k8s-sidecar:1.24.6
-quay.io/kiwigrid/k8s-sidecar:1.24.6
-docker.io/grafana/grafana:10.1.0
 ```
 
 or from a file arg (at the end):
@@ -80,8 +75,6 @@ or from a file arg (at the end):
 $ lq '.[3].kind' -r test/deploy.yaml
 $ lq -y '.[3].metadata' test/deploy.yaml
 ```
-
-The default input format is YAML and is what the binary is named for (and the most common primary usage case).
 
 ### TOML
 
@@ -94,11 +87,12 @@ parsing
 ```
 
 convert jq output back into toml (`-t`):
+
 ```sh
 $ lq -t '.package.metadata' Cargo.toml
 [binstall]
-bin-dir = "yq-{ target }/{ bin }{ format }"
-pkg-url = "{ repo }/releases/download/{ version }/yq-{ target }{ archive-suffix }"
+bin-dir = "lq-{ target }/{ bin }{ format }"
+pkg-url = "{ repo }/releases/download/{ version }lq-{ target }{ archive-suffix }"
 ```
 
 convert jq output to yaml (`-y`) and set explicit toml input when using stdin (`-T`):
@@ -118,7 +112,7 @@ $ lq '.profile' -c Cargo.toml
 {"release":{"lto":true,"panic":"abort","strip":"symbols"}}
 ```
 
-Add an `alias tq='lq --input=toml'` in your `.bashrc` / `.zshrc` (etc) to make this permanent if you find it useful.
+To shortcut passing input formats, you can add `alias tq='lq --input=toml'` in your `.bashrc` / `.zshrc` (etc).
 
 ### JSON Input
 
@@ -137,11 +131,13 @@ $ lq -Jy '.ingredients | keys' < test/guacamole.json
 - tomatoes
 ```
 
+Using JSON input is kind of like talking to `jq` directly, with the benefit that you can change output formats, or do inplace edits.
+
 ### Formats
 Default is going from `yaml` input to `jq` output to allow further pipes into `jq`.
 
-- Input switches are capitalised (`-J` json input, `-T` toml input) and shorthands for `--input=FORMAT`
-- Output switches lower cased (`-y` yaml output, `-t` toml output) and shorthands for `--output=FORMAT`
+- **Input** flags are **upper case** :: `-J` json input, `-T` toml input (shorthands for `--input=FORMAT`)
+- **Output** flags are **lower case** :: `-y` yaml output, `-t` toml output (shorthands for `--output=FORMAT`)
 
 Ex;
 - `lq` :: yaml -> jq output
@@ -153,8 +149,7 @@ Ex;
 - `jq -Jt` :: json -> toml
 
 Output formatting such as `-y` for YAML or `-t` for TOML will require the output from `jq` to be parseable json.
-If you pass on `-r`,`-c` or `-c` for raw/compact output, then this will generally not be parseable as json.
-
+If you pass on `-r`,`-c` or `-c` for raw/compact output, then this output may not be parseable as json.
 
 ### Advanced Features
 Two things you cannot do in `jq`:
@@ -168,13 +163,11 @@ curl -sSL https://github.com/prometheus-operator/prometheus-operator/releases/do
 ```
 
 #### In Place Edits
-Patch a json file
+Patch a json file ([without multiple pipes](https://github.com/jqlang/jq/issues/105)):
 
 ```sh
 lq -i '.SKIP_HOST_UPDATE=true' ~/.config/discord/settings.json
 ```
-
-[jq requires lots of pipes](https://github.com/jqlang/jq/issues/105).
 
 ### Advanced jq
 Any weird things you can do with `jq` works. Some common (larger) examples:

--- a/README.md
+++ b/README.md
@@ -178,14 +178,14 @@ Any weird things you can do with `jq` works. Some common (larger) examples:
 Select on yaml multidoc:
 
 ```sh
-$ lq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
+$ lq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
 8000
 ```
 
 Escaping keys with slashes etc in them:
 
 ```sh
-lq -y '.updates[] | select(.["package-ecosystem"] == "cargo") | .groups' .github/dependabot.yml
+lq '.updates[] | select(.["package-ecosystem"] == "cargo") | .groups' .github/dependabot.yml
 ```
 
 #### Modules

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/lq.svg)](https://crates.io/crates/lq)
 [![dependency status](https://deps.rs/repo/github/clux/lq/status.svg)](https://deps.rs/repo/github/clux/lq)
 
-A lightweight and portable [jq](https://jqlang.github.io/jq/) style cli for doing jq queries/filters/maps/transforms on **YAML**/**TOML**/**JSON** documents by converting to **JSON** and passing data to `jq`. Output is raw `jq` output / TOML / YAML.
+A lightweight and portable [jq](https://jqlang.github.io/jq/) style cli for doing jq queries/filters/maps/transforms on **YAML**/**TOML**/**JSON** documents by converting to **JSON** and passing data to `jq`. Output is raw `jq` output which can optionally be mapped to TOML or YAML.
 
 ## Installation
 

--- a/lq.rs
+++ b/lq.rs
@@ -64,6 +64,12 @@ struct Args {
         conflicts_with = "output"
     )]
     toml_output: bool,
+    /// Set input format to TOML (shortcut for --input=toml)
+    #[arg(short = 'T', long, default_value = "false", conflicts_with = "output")]
+    toml_input: bool,
+    /// Set input format to JSON (shortcut for --input=json)
+    #[arg(short = 'J', long, default_value = "false", conflicts_with = "output")]
+    json_input: bool,
 
     /// Edit the input file in place
     #[arg(short, long, default_value = "false")]
@@ -262,6 +268,12 @@ impl Args {
     fn infer_input_type(&self) -> Option<Input> {
         if let Some(input) = self.input {
             return Some(input); // always use what is asked for if explicit
+        }
+        if self.toml_input {
+            return Some(Input::Toml);
+        }
+        if self.json_input {
+            return Some(Input::Json);
         }
         let pbuf = self.file.clone()?;
         let ext_os = pbuf.extension()?;

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -59,6 +59,7 @@
 @test "toml" {
   run lq --input=toml -y '.package.edition' -r < Cargo.toml
   echo "$output" && echo "$output" | grep '2021'
+  run lq -Ty '.package.edition' -r < Cargo.toml
 
   run lq '.dependencies.clap.features' -c Cargo.toml
   echo "$output" && echo "$output" | grep '["cargo","derive"]'
@@ -87,6 +88,7 @@
 @test "json_input" {
   run lq --input=json ".ingredients | keys" -c < test/guacamole.json
   echo "$output" && echo "$output" | grep '["avocado","coriander","cumin","garlic","lime","onions","pepper","salt","tomatoes"]'
+  run lq -J ".ingredients | keys" -c < test/guacamole.json
 }
 
 @test "jq_modules" {


### PR DESCRIPTION
Adds input flags `-J` to alias `--input=json` and `-T` to alias `--input=toml`.

These do not clash with jq's cli flags.


### Rationale and Caveats
A potentially scary thing about this approach is that we could not do this for any new format. E.g. if we added RON support, we would not be able to add -R shorthand for ron input because `jq` has a `-R` flag.

Thinking that these (less primary, potential future formats) will just have to deal with the explicit --input=ron style.

We could of course do the coreutils binary style thing, but the short xq style binary names are already very much taken. Soo, that would leave us with `lqt` /  `lqy` / `lqj` etc for input, or `lqyy` / `lqjt`, or `lq y`, `lq j`, `lq jt`. Not nice.

In the end, going for this micro-optimisation because i write tools for myself that i want to be nice/convenient to use now, rather than idealistic for a future that probably never comes.